### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -21,6 +23,8 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Potential fix for [https://github.com/get-your-knowledge-here/caesar-cipher/security/code-scanning/2](https://github.com/get-your-knowledge-here/caesar-cipher/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimal permissions required for the `build` and `publish-npm` jobs. Based on the workflow's functionality, the `build` job only needs read access to the repository contents, while the `publish-npm` job requires write access to the `contents` scope to publish the package. These permissions will be added at the job level to ensure each job has only the privileges it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
